### PR TITLE
Fix NullPointerException in addRecord for None values.

### DIFF
--- a/src/main/scala/io/github/jchapuis/fs2/kafka/mock/impl/NativeMockKafkaConsumer.scala
+++ b/src/main/scala/io/github/jchapuis/fs2/kafka/mock/impl/NativeMockKafkaConsumer.scala
@@ -40,7 +40,7 @@ private[mock] class NativeMockKafkaConsumer(
   ): IO[Unit] = for {
     key <- keySerializer.serialize(topic, Headers.empty, key)
     value <- valueSerializer.serialize(topic, Headers.empty, value)
-    _ <- addRecord(topic, key, Some(value), timestamp)
+    _ <- addRecord(topic, key, Option(value), timestamp)
   } yield ()
 
   private def waitForConsumerToBeAssignedTo(topic: String): IO[Unit] =


### PR DESCRIPTION
While the `redact` method should be used for tombstoning, if one passes a `None` (or null, I guess) to `publish`, an NPE is the result.

The `addRecord` method uses Option, but gets a `Some(null)`. 