### PR TITLE
Add extended support for partitionsFor in the mock

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
 version = 3.8.1
+runner.dialect = scala213source3
 maxColumn = 120


### PR DESCRIPTION
The native kafka mock only supports this call if a consumer is already subscribed: make this more flexible